### PR TITLE
Create schema validator for the config file and add to the sample

### DIFF
--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Drazzilb08/daps/master/schemas/config-schema.json
+
 schedule:
   # Options:
   # run - will run a single time per run of main.py (mainly useful for testing with dry_run)

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -1,0 +1,720 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "definitions": {
+        "hourly": {
+            "type": "string",
+            "pattern": "^hourly\\([0-5][0-9]\\)$"
+        },
+        "daily": {
+            "type": "string",
+            "pattern": "^daily\\((?:([01]?[0-9]|2[0-3]):([0-5][0-9])\\|)?([01]?[0-9]|2[0-3]):([0-5][0-9])\\)$"
+        },
+        "weekly": {
+            "type": "string",
+            "pattern": "^weekly\\((monday|tuesday|wednesday|thursday|friday|saturday|sunday)@(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])\\)$"
+        },
+        "cron": {
+            "type": "string",
+            "pattern": "^cron\\(([^)\\s]+ [^)\\s]+ [^)\\s]+ [^)\\s]+ [^)\\s]+)\\)$"
+        },
+        "instance": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "api": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "url",
+                    "api"
+                ]
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "pattern": "^debug|info|warning|error$"
+        },
+        "schedule": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#/definitions/hourly"
+                },
+                {
+                    "$ref": "#/definitions/daily"
+                },
+                {
+                    "$ref": "#/definitions/weekly"
+                },
+                {
+                    "$ref": "#/definitions/cron"
+                }
+            ]
+        },
+        "stringOrNull": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "integerOrNull": {
+            "type": [
+                "integer",
+                "null"
+            ]
+        },
+        "discord": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "discord_webhook": {
+                    "$ref": "#/definitions/stringOrNull"
+                },
+                "channel_id": {
+                    "$ref": "#/definitions/integerOrNull"
+                }
+            },
+            "required": [
+                "discord_webhook",
+                "channel_id"
+            ]
+        }
+    },
+    "properties": {
+        "schedule": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "border_replacerr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "health_checkarr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "labelarr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "nohl": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "sync_gdrive": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "poster_cleanarr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "poster_renamerr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "renameinatorr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "unmatched_assets": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "upgradinatorr": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "nohl_bash": {
+                    "$ref": "#/definitions/schedule"
+                },
+                "jduparr": {
+                    "$ref": "#/definitions/schedule"
+                }
+            },
+            "required": [
+                "border_replacerr",
+                "health_checkarr",
+                "jduparr",
+                "labelarr",
+                "nohl",
+                "nohl_bash",
+                "poster_cleanarr",
+                "poster_renamerr",
+                "renameinatorr",
+                "sync_gdrive",
+                "unmatched_assets",
+                "upgradinatorr"
+            ]
+        },
+        "instances": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "radarr": {
+                    "$ref": "#/definitions/instance"
+                },
+                "sonarr": {
+                    "$ref": "#/definitions/instance"
+                },
+                "plex": {
+                    "$ref": "#/definitions/instance"
+                }
+            },
+            "required": [
+                "radarr",
+                "sonarr",
+                "plex"
+            ]
+        },
+        "discord": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "notifiarr_webhook": {
+                    "$ref": "#/definitions/stringOrNull"
+                },
+                "main": {
+                    "$ref": "#/definitions/discord"
+                },
+                "renameinatorr": {
+                    "$ref": "#/definitions/discord"
+                },
+                "upgradinatorr": {
+                    "$ref": "#/definitions/discord"
+                },
+                "poster_renamerr": {
+                    "$ref": "#/definitions/discord"
+                },
+                "nohl": {
+                    "$ref": "#/definitions/discord"
+                },
+                "labelarr": {
+                    "$ref": "#/definitions/discord"
+                },
+                "nohl_bash": {
+                    "$ref": "#/definitions/discord"
+                },
+                "jduparr": {
+                    "$ref": "#/definitions/discord"
+                }
+            },
+            "required": [
+                "notifiarr_webhook",
+                "main",
+                "renameinatorr",
+                "upgradinatorr",
+                "poster_renamerr",
+                "nohl",
+                "labelarr",
+                "nohl_bash",
+                "jduparr"
+            ]
+        },
+        "sync_gdrive": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "client_secret": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "object"
+                },
+                "gdrive_sa_location": {
+                    "type": "string"
+                },
+                "gdrive_sync": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "location": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "location"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "log_level",
+                "client_id",
+                "client_secret",
+                "token",
+                "gdrive_sa_location",
+                "gdrive_sync"
+            ]
+        },
+        "poster_renamerr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "sync_posters": {
+                    "type": "boolean"
+                },
+                "action_type": {
+                    "type": "string",
+                    "pattern": "^copy|move$"
+                },
+                "asset_folders": {
+                    "type": "boolean"
+                },
+                "print_only_renames": {
+                    "type": "boolean"
+                },
+                "border_replacerr": {
+                    "type": "boolean"
+                },
+                "library_names": {
+                    "type": "array"
+                },
+                "source_dirs": {
+                    "type": "array"
+                },
+                "destination_dir": {
+                    "type": "string"
+                },
+                "instances": {
+                    "type": "array"
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "sync_posters",
+                "action_type",
+                "asset_folders",
+                "print_only_renames",
+                "border_replacerr",
+                "library_names",
+                "source_dirs",
+                "destination_dir",
+                "instances"
+            ]
+        },
+        "border_replacerr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "source_dirs": {
+                    "type": "array"
+                },
+                "destination_dir": {
+                    "type": "string"
+                },
+                "border_width": {
+                    "type": "integer"
+                },
+                "skip": {
+                    "type": "boolean"
+                },
+                "border_colors": {
+                    "$ref": "#/definitions/stringOrNull"
+                },
+                "schedule": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "schedule": {
+                                        "type": "string"
+                                    },
+                                    "color": {
+                                        "type": [
+                                            "array",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "schedule",
+                                    "color"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "border_width",
+                "skip",
+                "border_colors",
+                "schedule"
+            ]
+        },
+        "unmatched_assets": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "instances": {
+                    "type": "array"
+                },
+                "ignore_root_folders": {
+                    "type": ["array", "null"]
+                },
+                "library_names": {
+                    "type": "array"
+                },
+                "ignore_collections": {
+                    "type": "array"
+                },
+                "source_dirs": {
+                    "type": "array"
+                }
+            },
+            "required": [
+                "log_level",
+                "ignore_root_folders",
+                "library_names",
+                "ignore_collections",
+                "source_dirs",
+                "instances"
+            ]
+        },
+        "poster_cleanarr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "library_names": {
+                    "type": "array"
+                },
+                "ignore_collections": {
+                    "type": "array"
+                },
+                "source_dirs": {
+                    "type": "array"
+                },
+                "instances": {
+                    "type": "array"
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "library_names",
+                "ignore_collections",
+                "source_dirs",
+                "instances"
+            ]
+        },
+        "upgradinatorr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "instances": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "count": {
+                                "type": "integer"
+                            },
+                            "tag_name": {
+                                "type": "string"
+                            },
+                            "unattended": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "count",
+                            "tag_name",
+                            "unattended"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "instances"
+            ]
+        },
+        "renameinatorr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "rename_folders": {
+                    "type": "boolean"
+                },
+                "count": {
+                    "type": "integer",
+                    "maximum": 10
+                },
+                "tag_name": {
+                    "type": "string"
+                },
+                "instances": {
+                    "type": "array"
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "rename_folders",
+                "instances"
+            ]
+        },
+        "nohl": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "maximum_searches": {
+                    "type": "integer",
+                    "maximum": 10
+                },
+                "print_files": {
+                    "type": "boolean"
+                },
+                "instances": {
+                    "type": "array"
+                },
+                "paths": {
+                    "type": "array"
+                },
+                "filters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "exclude_profiles": {
+                            "type": "string"
+                        },
+                        "exclude_movies": {
+                            "type": "array"
+                        },
+                        "exclude_series": {
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "exclude_profiles",
+                        "exclude_movies",
+                        "exclude_series"
+                    ]
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "instances",
+                "paths",
+                "maximum_searches",
+                "print_files",
+                "filters"
+            ]
+        },
+        "labelarr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "instances": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "library_names": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "plex_instances": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "labels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "library_names",
+                            "plex_instances",
+                            "labels"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "instances"
+            ]
+        },
+        "health_checkarr": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "dry_run": {
+                    "type": "boolean"
+                },
+                "instances": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "log_level",
+                "dry_run",
+                "instances"
+            ]
+        },
+        "bash_scripts": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                },
+                "nohl_bash": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "source": {
+                            "$ref": "#/definitions/stringOrNull"
+                        },
+                        "include": {
+                            "type": "array"
+                        },
+                        "exclude": {
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "source",
+                        "include",
+                        "exclude"
+                    ]
+                },
+                "jduparr": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "data_dir": {
+                            "$ref": "#/definitions/stringOrNull"
+                        },
+                        "silent": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "data_dir",
+                        "silent"
+                    ]
+                }
+            },
+            "required": [
+                "log_level",
+                "nohl_bash",
+                "jduparr"
+            ]
+        },
+        "main": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "log_level": {
+                    "$ref": "#/definitions/logLevel"
+                }
+            },
+            "required": [
+                "log_level"
+            ]
+        }
+    },
+    "required": [
+        "schedule",
+        "instances",
+        "discord",
+        "sync_gdrive",
+        "poster_renamerr",
+        "border_replacerr",
+        "unmatched_assets",
+        "poster_cleanarr",
+        "upgradinatorr",
+        "renameinatorr",
+        "nohl",
+        "labelarr",
+        "health_checkarr",
+        "bash_scripts",
+        "main"
+    ]
+}

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -3,49 +3,34 @@
     "type": "object",
     "additionalProperties": false,
     "definitions": {
+        "run": {
+            "type": "string",
+            "pattern": "^run$"
+        },
         "hourly": {
             "type": "string",
             "pattern": "^hourly\\([0-5][0-9]\\)$"
         },
         "daily": {
             "type": "string",
-            "pattern": "^daily\\((?:([01]?[0-9]|2[0-3]):([0-5][0-9])\\|)?([01]?[0-9]|2[0-3]):([0-5][0-9])\\)$"
+            "pattern": "^daily\\(((?:[01]?[0-9]|2[0-3]):([0-5][0-9])(?:\\|(?:[01]?[0-9]|2[0-3]):([0-5][0-9]))*)\\)$"
         },
         "weekly": {
             "type": "string",
             "pattern": "^weekly\\((monday|tuesday|wednesday|thursday|friday|saturday|sunday)@(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])\\)$"
         },
+        "monthly": {
+            "type": "string",
+            "pattern": "^monthly\\((?:28@(?:[01]?[0-9]|2[0-3]):([0-5][0-9]))\\)$"
+        },
         "cron": {
             "type": "string",
             "pattern": "^cron\\(([^)\\s]+ [^)\\s]+ [^)\\s]+ [^)\\s]+ [^)\\s]+)\\)$"
         },
-        "instance": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "url": {
-                        "type": "string"
-                    },
-                    "api": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "url",
-                    "api"
-                ]
-            }
-        },
-        "logLevel": {
-            "type": "string",
-            "pattern": "^debug|info|warning|error$"
-        },
         "schedule": {
             "oneOf": [
                 {
-                    "type": "null"
+                    "$ref": "#/definitions/run"
                 },
                 {
                     "$ref": "#/definitions/hourly"
@@ -57,9 +42,42 @@
                     "$ref": "#/definitions/weekly"
                 },
                 {
+                    "$ref": "#/definitions/monthly"
+                },
+                {
                     "$ref": "#/definitions/cron"
+                },
+                {
+                    "type": "null"
                 }
-            ]
+            ],
+            "description": "A schedule of either run, hourly, daily, weekly, monthly, or cron. If null, the task will not be scheduled.\nExamples:\nrun\nhourly(30)\ndaily(12:23)\ndaily(10:18|12:23)\nweekly(monday@12:00)\nmonthly(15@12:00)\ncron(0 0 * * *)"
+        },
+        "instance": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The URL of the instance, including the protocol and port. Example: http://localhost:8989",
+                        "pattern": "^https?://[^\\s]+(:[0-9]+)?$"
+                    },
+                    "api": {
+                        "type": "string",
+                        "description": "The API key of the instance"
+                    }
+                },
+                "required": [
+                    "url",
+                    "api"
+                ]
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "pattern": "^debug|info|warning|error$"
         },
         "stringOrNull": {
             "type": [
@@ -78,16 +96,25 @@
             "additionalProperties": false,
             "properties": {
                 "discord_webhook": {
-                    "$ref": "#/definitions/stringOrNull"
+                    "$ref": "#/definitions/stringOrNull",
+                    "description": "The Discord webhook URL to send messages to. If null, no messages will be sent.",
+                    "pattern": "^https?://[^\\s]+(:[0-9]+)?$"
                 },
                 "channel_id": {
-                    "$ref": "#/definitions/integerOrNull"
+                    "$ref": "#/definitions/integerOrNull",
+                    "description": "The Discord channel ID to send messages to if you are using Notifarr. If null, no messages will be sent.\nhttps://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID"
                 }
             },
             "required": [
                 "discord_webhook",
                 "channel_id"
             ]
+        },
+        "uniqueArray": {
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
         }
     },
     "properties": {
@@ -172,7 +199,9 @@
             "additionalProperties": false,
             "properties": {
                 "notifiarr_webhook": {
-                    "$ref": "#/definitions/stringOrNull"
+                    "$ref": "#/definitions/stringOrNull",
+                    "pattern": "^https?://[^\\s]+(:[0-9]+)?$",
+                    "description": "Notifiarr Passthrough URL. If null, no messages will be sent."
                 },
                 "main": {
                     "$ref": "#/definitions/discord"
@@ -287,16 +316,16 @@
                     "type": "boolean"
                 },
                 "library_names": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "source_dirs": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "destination_dir": {
                     "type": "string"
                 },
                 "instances": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 }
             },
             "required": [
@@ -324,7 +353,7 @@
                     "type": "boolean"
                 },
                 "source_dirs": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "destination_dir": {
                     "type": "string"
@@ -385,7 +414,7 @@
                     "$ref": "#/definitions/logLevel"
                 },
                 "instances": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "ignore_root_folders": {
                     "type": [
@@ -394,13 +423,13 @@
                     ]
                 },
                 "library_names": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "ignore_collections": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "source_dirs": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 }
             },
             "required": [
@@ -423,16 +452,16 @@
                     "type": "boolean"
                 },
                 "library_names": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "ignore_collections": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "source_dirs": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "instances": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 }
             },
             "required": [
@@ -505,7 +534,7 @@
                     "type": "string"
                 },
                 "instances": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 }
             },
             "required": [
@@ -533,10 +562,10 @@
                     "type": "boolean"
                 },
                 "instances": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "paths": {
-                    "type": "array"
+                    "$ref": "#/definitions/uniqueArray"
                 },
                 "filters": {
                     "type": "object",
@@ -546,10 +575,10 @@
                             "type": "string"
                         },
                         "exclude_movies": {
-                            "type": "array"
+                            "$ref": "#/definitions/uniqueArray"
                         },
                         "exclude_series": {
-                            "type": "array"
+                            "$ref": "#/definitions/uniqueArray"
                         }
                     },
                     "required": [
@@ -585,22 +614,13 @@
                         "type": "object",
                         "properties": {
                             "library_names": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
+                                "$ref": "#/definitions/uniqueArray"
                             },
                             "plex_instances": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
+                                "$ref": "#/definitions/uniqueArray"
                             },
                             "labels": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
+                                "$ref": "#/definitions/uniqueArray"
                             }
                         },
                         "required": [
@@ -628,10 +648,7 @@
                     "type": "boolean"
                 },
                 "instances": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "$ref": "#/definitions/uniqueArray"
                 }
             },
             "required": [
@@ -655,10 +672,10 @@
                             "$ref": "#/definitions/stringOrNull"
                         },
                         "include": {
-                            "type": "array"
+                            "$ref": "#/definitions/uniqueArray"
                         },
                         "exclude": {
-                            "type": "array"
+                            "$ref": "#/definitions/uniqueArray"
                         }
                     },
                     "required": [

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -388,7 +388,10 @@
                     "type": "array"
                 },
                 "ignore_root_folders": {
-                    "type": ["array", "null"]
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "library_names": {
                     "type": "array"


### PR DESCRIPTION
The schema validator can make sure that the fields which are required are present and are of the correct type.

You can test it from my fork by changing the URL to https://raw.githubusercontent.com/GeneralPractitioner-GP/daps/schema-validator/schemas/config-schema.json

It's the first one that I've created outside of testing them out on other projects. Thought it might help those that are confused by what is required.

I tested it on the example and my config file. 

Recyclarr has some good docs on how to get it to work
https://recyclarr.dev/wiki/schema-validation/