### PR TITLE
Add Symlink and Hardlink Ex and Schema; Fix Schema for `season_monitored_threshold`

### DIFF
--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -173,7 +173,7 @@ poster_renamerr:
   log_level: info
   dry_run: false
   sync_posters: true # <- This will run sync_gdrive before renaming
-  action_type: copy # <- Options: copy, move
+  action_type: copy # <- Options: copy, move, hardlink, symlink (Note: 'hardlink' and 'symlink' require "source_dirs" and "destination_dir" to be on the same filesystem)
   asset_folders: false # <- This will copy the folder structure of the source_dir to the destination_dir, this MUST be the same as you use in Plex-Meta-Manager
   print_only_renames: false # <- This will print the renames to the log, but will not actually rename anything
   # This will integrate border_replacer with poster_renamerr, set this to true if you want to use them at the same time (no need to schedule border_replacer)

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -519,7 +519,9 @@
                                 "type": "boolean"
                             },
                             "season_monitored_threshold": {
-                                "type": "number"
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
                             }
                         },
                         "required": [

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -311,7 +311,7 @@
                 },
                 "action_type": {
                     "type": "string",
-                    "pattern": "^copy|move$"
+                    "pattern": "^copy|move|hardlink|symlink$"
                 },
                 "asset_folders": {
                     "type": "boolean"

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -512,12 +512,14 @@
                             "tag_name": {
                                 "type": "string"
                             },
-                            "ignore_tag":
-                            {
+                            "ignore_tag": {
                                 "type": "string"
                             },
                             "unattended": {
                                 "type": "boolean"
+                            },
+                            "season_monitored_threshold": {
+                                "type": "number"
                             }
                         },
                         "required": [


### PR DESCRIPTION
- **Added `symlink` and `hardlink` options to `action_type`**:
  - Updated documentation and configuration examples to include `hardlink` and `symlink` as valid options.
  - Included an inline comment warning that `hardlink` and `symlink` require `source_dirs` and `destination_dir` to be on the same filesystem (important for container users).

    ```yaml
      action_type: copy # <- Options: copy, move, hardlink, symlink (Note: 'hardlink' and 'symlink' require "source_dirs" and "destination_dir" to be on the same filesystem)
    ```

- **Updated Schema for `season_monitored_threshold`**:
  - Added `season_monitored_threshold` to the schema with type `number`.
  - This fixes schema validation errors in the default config example.