### PR TITLE
remove cases where multiple files could contribute

### DIFF
--- a/util/construct.py
+++ b/util/construct.py
@@ -30,26 +30,30 @@ def create_collection(title: str, normalized_title: str, files: list[str]) -> di
         'title': title,
         'year': None,
         'normalized_title': normalized_title,
-        'files': files,
+        'files': [files[-1]],
         'alternate_titles': variants['alternate_titles'],
         'normalized_alternate_titles': variants['normalized_alternate_titles'],
     }
 
 def create_series(title: str, year: Optional[int], tvdb_id: Optional[int], imdb_id: Optional[str], normalized_title: str, files: list[str]) -> dict:
     # Extract season numbers from file names
-    season_numbers = []
+    season_numbers_dict = {}
+    series_poster = None
     for file_path in files:
         base = os.path.basename(file_path)
         if "Specials" in base:
-            season_numbers.append(0)
+            season_numbers_dict[0] = file_path
         else:
             match = re.search(season_number_regex, base)
             if match:
-                season_numbers.append(int(match.group(1)))
+                season_numbers_dict[int(match.group(1))] = file_path
+            else:
+                series_poster = file_path
 
     # Remove duplicates and sort
-    season_numbers = sorted(set(season_numbers))
-
+    season_numbers = sorted(season_numbers_dict.keys())
+    final_files = list(season_numbers_dict.values())
+    final_files.append(series_poster) if series_poster else None
     return {
         'type': 'series',
         'title': title,
@@ -57,7 +61,7 @@ def create_series(title: str, year: Optional[int], tvdb_id: Optional[int], imdb_
         'tvdb_id': tvdb_id,
         'imdb_id': imdb_id,
         'normalized_title': normalized_title,
-        'files': files,
+        'files': final_files,
         'season_numbers': season_numbers,
     }
 
@@ -69,5 +73,5 @@ def create_movie(title: str, year: Optional[int], tmdb_id: Optional[int], imdb_i
         'tmdb_id': tmdb_id,
         'imdb_id': imdb_id,
         'normalized_title': normalized_title,
-        'files': files,
+        'files': [files[-1]],
     }


### PR DESCRIPTION
For movies & collections only a single file can ever exist, so take the last one while processing a single directory.

For a series, apply similar logic but apply it on the poster and each individual season as well.