### PR TITLE
Add ignore tag filtering to process_instance

### DIFF
--- a/modules/renameinatorr.py
+++ b/modules/renameinatorr.py
@@ -108,6 +108,17 @@ def process_instance(
     media_dict: List[Dict[str, Any]] = app.get_parsed_media()
     count: int = get_count_for_instance_type(config, instance_type, logger)
     tag_id: Any = None
+
+    # Ignore-tag filtering: skip items with the ignore tag, if configured
+    skipped_count = 0
+    if getattr(config, "ignore_tag", None):
+        ignore_tag_id = app.get_tag_id_from_name(config.ignore_tag)
+        if ignore_tag_id:
+            before_count = len(media_dict)
+            media_dict = [item for item in media_dict if ignore_tag_id not in item.get("tags", [])]
+            skipped_count = before_count - len(media_dict)
+            if skipped_count > 0:
+                logger.info(f"Skipped {skipped_count} items due to ignore tag '{config.ignore_tag}'.")
     # Tagging logic: filter untagged, clear if all tagged
     if getattr(config, "tag_name", None):
         tag_id = app.get_tag_id_from_name(config.tag_name)

--- a/util/template/config_template.json
+++ b/util/template/config_template.json
@@ -90,6 +90,7 @@
     "radarr_count": 0,
     "sonarr_count": 0,
     "tag_name": "",
+    "ignore_tags": "",
     "enable_batching": false,
     "instances": []
   },


### PR DESCRIPTION
Introduces logic in process_instance to skip items with a configured ignore tag, logging the number of skipped items. Also updates the config template to include an 'ignore_tags' field for configuration.